### PR TITLE
Ajuste da JMenuBar para macOS

### DIFF
--- a/src/principal/Aplicacao.java
+++ b/src/principal/Aplicacao.java
@@ -53,6 +53,9 @@ public class Aplicacao {
      * @param args the command line arguments
      */
     public static void main(String[] args) {
+        System.setProperty("apple.laf.useScreenMenuBar", "true");
+        System.setProperty("apple.awt.application.name", "brModelo");
+
         initLookAndFeel();
         JFrame.setDefaultLookAndFeelDecorated(true);
 


### PR DESCRIPTION
Ajuste de propriedade para a JMenuBar ser mostrada na menu bar do macOS e não na janela da aplicação.

As aplicações rodando no macOS tem esse comportamento por padrão.